### PR TITLE
test for orderbook at strike, if none try again at strike + 25

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const bybitOptions = new USDCOptionClient({
   testnet: false
 });
 
-const { toBN, getExpirySymbol } = require("../utils")(web3, bybitSpot);
+const { toBN, getExpirySymbol } = require("../utils")(web3, bybitSpot, bybitOptions);
 
 // Map closest strikes to positions
 let hedges = {};
@@ -178,7 +178,7 @@ const watchPurchaseEvents = () => {
       });
       const amountToHedge = (underlyingPurchased * 2 * poolShare) / 100;
       // Get symbol for Bybit expiry
-      const expirySymbol = getExpirySymbol(
+      const expirySymbol = await getExpirySymbol(
         epochExpiry,
         apStrike,
         premiumPerStraddle
@@ -259,7 +259,7 @@ async function run(isInit) {
     // Get symbol for Bybit expiry
     let { apStrike, underlyingPurchased, cost, straddleId } = purchase;
     const premiumPerStraddle = cost / (underlyingPurchased * 2) / 1e8;
-    const expirySymbol = getExpirySymbol(
+    const expirySymbol = await getExpirySymbol(
       epochExpiry,
       purchase.apStrike / 1e8,
       premiumPerStraddle
@@ -313,3 +313,4 @@ async function run(isInit) {
 }
 
 run(true);
+

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,10 +1,11 @@
-function utils(web3, bybitSpot) {
+function utils(web3, bybitSpot, bybitOptions) {
+
   const toBN = n => web3.utils.toBN(n);
 
   const getLastPrice = async () =>
     parseFloat((await bybitSpot.getLastTradedPrice("ETHUSDT")).result.price);
 
-  const getExpirySymbol = (expiry, lastPrice, premium) => {
+  const getExpirySymbol = async (expiry, lastPrice, premium) => {
     const expiryDate = new Date(expiry * 1000);
     const month = expiryDate.toLocaleString("default", { month: "short" });
     const day = expiryDate.getUTCDate();
@@ -15,7 +16,15 @@ function utils(web3, bybitSpot) {
     console.log("get expiry symbol:", lastPrice, premium);
     // Compute strike closest to last price after premium
     let closest = (Math.floor((lastPrice - premium) / 25) * 25).toString();
-    return `ETH-${day}${month.toUpperCase()}${year}-${closest}-P`;
+    let testString = `ETH-${day}${month.toUpperCase()}${year}-${closest}-P`;
+
+    let orderbook = (await bybitOptions.getOrderBook(testString));
+    if (orderbook.result.length !== 0) {
+      return testString;
+    } else {
+      closest = (Math.floor((lastPrice - premium) / 25) * 25) + 25
+      return `ETH-${day}${month.toUpperCase()}${year}-${closest}-P`;
+    }
   };
 
   return {


### PR DESCRIPTION
Hi,

I noticed today that the script was looking for liquidity at strike 1175 for 18th December, which doesn't exist on bybit. I changed the utils function to include a liquidity test, if there's nothing on the orderbook for the strike tested, it instead returns the strike + 25. 

I've assumed there will always be strikes at X,X50 and X,X00. 

Cheers